### PR TITLE
Fixing OOM crash docker issues on prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,16 +52,22 @@ WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED 1
 
 # Re-run and install only production/runtime dependencies
-COPY --from=builder /app/package.json ./
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install git ca-certificates && \
-    yarn install --production --ignore-scripts --prefer-offline && \
-    apt-get -y remove git && \
-    apt-get -y autoremove && \
-    apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/tmp/* && \
-    rm -rf /usr/local/share/.cache
+#COPY --from=builder /app/package.json ./
+#RUN apt-get -y update && \
+#    apt-get -y --no-install-recommends install git ca-certificates && \
+#    yarn install --production --ignore-scripts --prefer-offline && \
+#    apt-get -y remove git && \
+#    apt-get -y autoremove && \
+#    apt-get -y clean && \
+#    rm -rf /var/lib/apt/lists/* && \
+#    rm -rf /var/tmp/* && \
+#    rm -rf /usr/local/share/.cache
+
+# Instead of above, copy just node modules from our builder
+# TODO: This must be done because our "prod" deps aren't enough and cause crashing, someone fix me
+#       if you wish to fix me, the issue is an insane random 137 "oom" crash which even with debug logging
+#       it doesn't log anything.
+COPY --from=builder /app/node_modules ./node_modules
 
 # Copy over needed files
 COPY . .


### PR DESCRIPTION
There's a bug in the code somewhere, some dependencies are in the "devDependencies" in package.json and should be in the prod dependencies.  This was causing an insane untraceable bug causing the code to randomly crash in production.