### PR TITLE
Fixing Github Actions Bug - Only run on code additions to master against staging

### DIFF
--- a/.github/workflows/staging-deploy-on-merge.yml
+++ b/.github/workflows/staging-deploy-on-merge.yml
@@ -1,12 +1,12 @@
 name: Staging - Deploy Frontend on Merge
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [master]
   push:
     branches:
       - master
+#  pull_request:
+#    types: [closed]
+#    branches: [master]
 
 
 defaults:


### PR DESCRIPTION
This fixes a minor bug in when Github Actions are run, it would previously run two separate jobs when we only want one.