### PR TITLE
Update Join/Leave event buttons to a button menu UI

### DIFF
--- a/components/Icons/index.ts
+++ b/components/Icons/index.ts
@@ -13,6 +13,7 @@ export { default as EditIcon } from "@material-ui/icons/EditOutlined";
 export { default as EmailIcon } from "@material-ui/icons/EmailOutlined";
 export { default as PersonIcon } from "@material-ui/icons/EmojiPeopleOutlined";
 export { default as CalendarIcon } from "@material-ui/icons/EventOutlined";
+export { default as ExpandLessIcon } from "@material-ui/icons/ExpandLessOutlined";
 export { default as ExpandMoreIcon } from "@material-ui/icons/ExpandMoreOutlined";
 export { default as FilterIcon } from "@material-ui/icons/FilterListOutlined";
 export { default as FlagIcon } from "@material-ui/icons/Flag";

--- a/deployment/web-frontend/values-dev.yaml
+++ b/deployment/web-frontend/values-dev.yaml
@@ -18,10 +18,10 @@ deployment:
   resources:
     limits:
      cpu: 500m
-     memory: 200Mi
+     memory: 300Mi
     requests:
      cpu: 50m
-     memory: 200Mi
+     memory: 300Mi
 
 # Using an custom .env file injected into the running container.  See: templates/env.yaml
 envFile: .env.development

--- a/features/communities/events/AttendanceMenu.tsx
+++ b/features/communities/events/AttendanceMenu.tsx
@@ -1,0 +1,112 @@
+import { ListItemText } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import Button from "components/Button";
+import { CheckIcon, ExpandLessIcon, ExpandMoreIcon } from "components/Icons";
+import Menu, { MenuItem } from "components/Menu";
+import { useTranslation } from "i18n";
+import { COMMUNITIES } from "i18n/namespaces";
+import { AttendanceState } from "proto/events_pb";
+import { useState } from "react";
+
+const useStyles = makeStyles((theme) => ({
+  menuListItem: {
+    display: "flex",
+    gap: theme.spacing(2),
+  },
+}));
+
+export default function AttendanceMenu({
+  loading,
+  onChange,
+  attendanceState,
+  id,
+}: {
+  loading: boolean;
+  onChange: (attendanceState: AttendanceState) => void;
+  attendanceState: AttendanceState;
+  id: string;
+}) {
+  const { t } = useTranslation([COMMUNITIES]);
+  const classes = useStyles();
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const handleChange = (attendanceState: AttendanceState) => {
+    onChange(attendanceState);
+    setAnchorEl(null);
+  };
+
+  /* @todo: this id can be unique and not passed from outside when we have Reeact 18 useId */
+  const buttonId = `${id}-button`;
+  const menuId = `${id}-menu`;
+
+  return (
+    <>
+      <Button
+        id={buttonId}
+        aria-controls={open ? menuId : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        loading={loading}
+        variant={
+          attendanceState === AttendanceState.ATTENDANCE_STATE_GOING
+            ? "outlined"
+            : "contained"
+        }
+      >
+        {attendanceState === AttendanceState.ATTENDANCE_STATE_GOING
+          ? t("communities:going_to_event")
+          : t("communities:join_event")}
+
+        {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+      </Button>
+
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": buttonId,
+        }}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+      >
+        <MenuItem
+          onClick={() => handleChange(AttendanceState.ATTENDANCE_STATE_GOING)}
+          classes={{ root: classes.menuListItem }}
+        >
+          <ListItemText primary={t("communities:going_to_event")} />
+          {attendanceState === AttendanceState.ATTENDANCE_STATE_GOING && (
+            <CheckIcon />
+          )}
+        </MenuItem>
+        <MenuItem
+          onClick={() =>
+            handleChange(AttendanceState.ATTENDANCE_STATE_NOT_GOING)
+          }
+          classes={{ root: classes.menuListItem }}
+        >
+          <ListItemText primary={t("communities:not_going_to_event")} />
+          {attendanceState === AttendanceState.ATTENDANCE_STATE_NOT_GOING && (
+            <CheckIcon />
+          )}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/features/communities/events/AttendanceMenu.tsx
+++ b/features/communities/events/AttendanceMenu.tsx
@@ -87,7 +87,9 @@ export default function AttendanceMenu({
         }}
       >
         <MenuItem
-          onClick={() => handleChange(AttendanceState.ATTENDANCE_STATE_GOING)}
+          onClick={() => {
+            handleChange(AttendanceState.ATTENDANCE_STATE_GOING);
+          }}
           classes={{ root: classes.menuListItem }}
         >
           <ListItemText primary={t("communities:going_to_event")} />
@@ -96,9 +98,9 @@ export default function AttendanceMenu({
           )}
         </MenuItem>
         <MenuItem
-          onClick={() =>
-            handleChange(AttendanceState.ATTENDANCE_STATE_NOT_GOING)
-          }
+          onClick={() => {
+            handleChange(AttendanceState.ATTENDANCE_STATE_NOT_GOING);
+          }}
           classes={{ root: classes.menuListItem }}
         >
           <ListItemText primary={t("communities:not_going_to_event")} />

--- a/features/communities/events/EventPage.test.tsx
+++ b/features/communities/events/EventPage.test.tsx
@@ -84,9 +84,10 @@ describe("Event page", () => {
     // Event image
     expect(screen.getByRole("img", { name: "" })).toBeVisible();
 
-    expect(
-      screen.getByRole("button", { name: t("communities:leave_event") })
-    ).toBeVisible();
+    const attendanceMenuButton = screen.getByRole("button", {
+      name: t("communities:going_to_event"),
+    });
+    expect(attendanceMenuButton).toBeVisible();
 
     // Event details
     expect(
@@ -209,10 +210,14 @@ describe("Event page", () => {
       renderEventPage();
       await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
-      const attendanceButton = screen.getByRole("button", {
-        name: t("communities:leave_event"),
+      const attendanceMenuButton = screen.getByRole("button", {
+        name: t("communities:going_to_event"),
       });
-      userEvent.click(attendanceButton);
+      userEvent.click(attendanceMenuButton);
+      const leaveEventOption = screen.getByRole("menuitem", {
+        name: t("communities:not_going_to_event"),
+      });
+      userEvent.click(leaveEventOption);
 
       expect(
         await screen.findByRole("button", { name: t("communities:join_event") })
@@ -237,9 +242,14 @@ describe("Event page", () => {
       renderEventPage();
       await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
-      userEvent.click(
-        screen.getByRole("button", { name: t("communities:leave_event") })
-      );
+      const attendanceMenuButton = screen.getByRole("button", {
+        name: t("communities:going_to_event"),
+      });
+      userEvent.click(attendanceMenuButton);
+      const leaveEventOption = screen.getByRole("menuitem", {
+        name: t("communities:not_going_to_event"),
+      });
+      userEvent.click(leaveEventOption);
 
       await assertErrorAlert(errorMessage);
     });

--- a/features/communities/events/EventPage.tsx
+++ b/features/communities/events/EventPage.tsx
@@ -30,6 +30,7 @@ import dayjs from "utils/dayjs";
 import makeStyles from "utils/makeStyles";
 
 import CommentTree from "../discussions/CommentTree";
+import AttendanceMenu from "./AttendanceMenu";
 import EventAttendees from "./EventAttendees";
 import EventOrganizers from "./EventOrganizers";
 import { useEvent } from "./hooks";
@@ -156,13 +157,9 @@ export default function EventPage({
     error: setEventAttendanceError,
     mutate: setEventAttendance,
   } = useMutation<Event.AsObject, RpcError, AttendanceState>(
-    (currentAttendanceState) => {
-      const attendanceStateToSet =
-        currentAttendanceState === AttendanceState.ATTENDANCE_STATE_GOING
-          ? AttendanceState.ATTENDANCE_STATE_NOT_GOING
-          : AttendanceState.ATTENDANCE_STATE_GOING;
+    (newEventAttendance: AttendanceState) => {
       return service.events.setEventAttendance({
-        attendanceState: attendanceStateToSet,
+        attendanceState: newEventAttendance,
         eventId,
       });
     },
@@ -247,21 +244,15 @@ export default function EventPage({
                     <Button component="a">{t("communities:edit_event")}</Button>
                   </Link>
                 ) : null}
-                <Button
+
+                <AttendanceMenu
                   loading={isSetEventAttendanceLoading}
-                  onClick={() => setEventAttendance(event.attendanceState)}
-                  variant={
-                    event.attendanceState ===
-                    AttendanceState.ATTENDANCE_STATE_GOING
-                      ? "outlined"
-                      : "contained"
+                  onChange={(attendanceState) =>
+                    setEventAttendance(attendanceState)
                   }
-                >
-                  {event.attendanceState ===
-                  AttendanceState.ATTENDANCE_STATE_GOING
-                    ? t("communities:leave_event")
-                    : t("communities:join_event")}
-                </Button>
+                  attendanceState={event.attendanceState}
+                  id="event-page-attendance"
+                />
               </div>
 
               <div className={classes.eventTimeContainer}>

--- a/features/communities/events/EventPage.tsx
+++ b/features/communities/events/EventPage.tsx
@@ -241,7 +241,9 @@ export default function EventPage({
                     href={routeToEditEvent(event.eventId, event.slug)}
                     passHref
                   >
-                    <Button component="a">{t("communities:edit_event")}</Button>
+                    <Button component="a" variant="outlined">
+                      {t("communities:edit_event")}
+                    </Button>
                   </Link>
                 ) : null}
 

--- a/features/communities/locales/en.json
+++ b/features/communities/locales/en.json
@@ -76,6 +76,8 @@
     "invalid_time": "Time must be in 24-hour format HH:MM.",
     "join_event": "Join event",
     "leave_event": "Leave event",
+    "going_to_event": "I'm going",
+    "not_going_to_event": "Not going",
     "link_required": "Please provide a meeting link for the event.",
     "load_more_attendees": "Load more attendees",
     "load_more_organizers": "Load more organizers",

--- a/features/communities/locales/es.json
+++ b/features/communities/locales/es.json
@@ -48,6 +48,8 @@
   "invalid_time": "La hora debe estar en formato 24 horas, HH:MM.",
   "join_event": "Unirse al evento",
   "leave_event": "Dejar el evento",
+  "going_to_event": "Asistiré",
+  "not_going_to_event": "No asistiré",
   "load_more_organizers": "Cargar más organizadores",
   "load_more_attendees": "Cargar más asistentes",
   "location": "Ubicación",

--- a/features/communities/locales/pt.json
+++ b/features/communities/locales/pt.json
@@ -65,6 +65,8 @@
   "events_title": "Eventos",
   "invalid_time": "O horário deve estar no formato 24 horas, HH:MM.",
   "leave_event": "Abandonar evento",
+  "going_to_event": "Vou participar",
+  "not_going_to_event": "Não irei",
   "load_more_attendees": "Carregar mais participantes",
   "load_more_organizers": "Carregar mais organizadores",
   "location": "Local",


### PR DESCRIPTION
Update the buttons to "Join event" and "Leave event" to a button menu inspired on Facebook's UI. 

* [Context in slack.](https://couchersorg.slack.com/archives/C01FAQY1H8X/p1652215592840019?thread_ts=1652213552.987869&cid=C01FAQY1H8X)
* This is a previous step to adding this same button on the event cards of the new dashboard. See https://github.com/Couchers-org/web-frontend/issues/32

🇵🇹 I added the Portuguese translation based on a mix between what I know and Google Translate.

https://user-images.githubusercontent.com/1557348/171629621-3ee54f88-2fdf-4f5c-9a10-659fa7c89581.mov

<img width="402" alt="Screen Shot 2022-06-02 at 14 29 51" src="https://user-images.githubusercontent.com/1557348/171629645-31e4d1a6-1921-4324-b2d3-e05dc7688a9a.png">

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

