### PR TITLE
fix dev mapbox token

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,7 @@ NEXT_PUBLIC_COUCHERS_ENV=dev
 NEXT_PUBLIC_API_BASE_URL=https://api.couchers.dev
 NEXT_PUBLIC_MEDIA_BASE_URL="https://media.couchers.dev"
 NEXT_PUBLIC_IS_POST_BETA_ENABLED=true
-NEXT_PUBLIC_MAPBOX_KEY="pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzVnaXA0MGdmejJ4bGFrdTdrNjA0NCJ9.1VAPRbE6a_kwGw1kucppJw"
+NEXT_PUBLIC_MAPBOX_KEY="pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzY4eHd2MGVpcTJ0bGdhdGhvbHhlbiJ9.u5zvDeFE9H8itTK_dNp7Pg"
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
 NEXT_PUBLIC_TILE_URL="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 NEXT_PUBLIC_TILE_ATTRIBUTION="Map data &copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors"


### PR DESCRIPTION
Because the default dev environment uses the 'dev' env file while running the frontend locally, the mapbox token used needs to support both couchers.dev and localhost.

I've updated the token on mapbox and have fixed the dev env file here.