### PR TITLE
fix: clear protected data in localStorage of cache

### DIFF
--- a/features/auth/Logout.tsx
+++ b/features/auth/Logout.tsx
@@ -16,7 +16,7 @@ export default function Logout() {
   const logout = useMutation<void, RpcError>(
     async () => {
       authActions.logout();
-      queryClient.resetQueries();
+      queryClient.clear();
     },
     {
       onSuccess: () => {

--- a/features/landing/LandingPage.tsx
+++ b/features/landing/LandingPage.tsx
@@ -20,6 +20,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Trans, useTranslation } from "next-i18next";
 import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "react-query";
 import vercelLogo from "resources/vercel.svg";
 import makeStyles from "utils/makeStyles";
 
@@ -96,6 +97,15 @@ export default function LandingPage() {
 
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => setIsMounted(true), []);
+
+  // This makes sure anything didn't get cleared up in the query cache in the Logout
+  // component definitely gets cleared here when redirected to the landing page
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (!authState.authenticated) {
+      queryClient.clear();
+    }
+  }, [queryClient, authState.authenticated]);
 
   const moreContentRef = useRef<HTMLHeadingElement>(null);
   const scrollToMore = () => {


### PR DESCRIPTION
Previously, when you log out, it would not reliably clear most of the data - the best it did when I tried locally is it cleared everything but still leaves the previously logged in user info in the cache. It is probably not ideal considering profile data are only meant to be accessible by authenticated users only!

This also fixes the issue mentioned in https://github.com/TanStack/query/issues/1951, which has been bugging me for a while (lol) and I just remembered it still being an issue after checking and poking around the app a bit recently.

**Before the fix:**
![before-fix](https://user-images.githubusercontent.com/13669362/188249529-cb613503-8159-47c2-9ec7-7e2391ff04f7.png)

**After the fix:**
![after-fix](https://user-images.githubusercontent.com/13669362/188249537-918afcf2-0e5c-4fd8-af70-8b7f274b04d1.png)


<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
