### PR TITLE
fix: case sensitive username input in reset password form

### DIFF
--- a/features/auth/password/ResetPassword.test.tsx
+++ b/features/auth/password/ResetPassword.test.tsx
@@ -62,6 +62,22 @@ describe("ResetPassword", () => {
     expect(resetPasswordMock).toHaveBeenCalledWith("test");
   });
 
+  it("submits the reset password request even if the username is typed in mixed casing", async () => {
+    render(<ResetPassword />, { wrapper });
+
+    userEvent.type(
+      screen.getByLabelText(t("auth:reset_password_form.enter_email")),
+      "TeST"
+    );
+    userEvent.click(screen.getByRole("button", { name: t("global:submit") }));
+
+    expect(
+      await screen.findByText(t("auth:reset_password_form.success_message"))
+    ).toBeVisible();
+    expect(resetPasswordMock).toHaveBeenCalledTimes(1);
+    expect(resetPasswordMock).toHaveBeenCalledWith("test");
+  });
+
   it("shows an error alert if the reset password request failed", async () => {
     jest.spyOn(console, "error").mockReturnValue(undefined);
     resetPasswordMock.mockRejectedValue(new Error("GRPC error"));

--- a/features/auth/password/ResetPassword.tsx
+++ b/features/auth/password/ResetPassword.tsx
@@ -12,12 +12,16 @@ import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
 import makeStyles from "utils/makeStyles";
+import { lowercaseAndTrimField } from "utils/validation";
 
 const useStyles = makeStyles((theme) => ({
   form: {
     "& > * + *": {
       marginBlockStart: theme.spacing(1),
     },
+  },
+  main: {
+    padding: theme.spacing(0, 3),
   },
   textField: {
     width: "100%",
@@ -42,11 +46,11 @@ export default function ResetPassword() {
   );
 
   const onSubmit = handleSubmit(({ userId }) => {
-    resetPassword(userId);
+    resetPassword(lowercaseAndTrimField(userId));
   });
 
   return (
-    <>
+    <main className={classes.main}>
       <HtmlMeta title={t("auth:reset_password")} />
       <PageTitle>{t("auth:reset_password")}</PageTitle>
       {error && <Alert severity="error">{error.message}</Alert>}
@@ -57,6 +61,7 @@ export default function ResetPassword() {
           inputRef={register({ required: true })}
           label={t("auth:reset_password_form.enter_email")}
           name="userId"
+          variant="standard"
           fullWidth
         />
         <Button loading={isLoading} type="submit">
@@ -68,6 +73,6 @@ export default function ResetPassword() {
           </Typography>
         )}
       </form>
-    </>
+    </main>
   );
 }


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
This PR addresses the issue mentioned in the title, so that users no longer have to type their username/email precisely, just like how they work in the login/signup form across the Couchers app.

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
