### PR TITLE
feat: send sign up tracking event when someone becomes a full user

### DIFF
--- a/components/AppRoute.tsx
+++ b/components/AppRoute.tsx
@@ -103,6 +103,9 @@ export default function AppRoute({
       ) : (
         <>
           <Navigation />
+          {/* Temporary container injected for marketing to test dynamic "announcements".
+           * Find a better spot to componentise this code once plan is more finalised with this */}
+          <div id="announcements"></div>
           <Container
             className={classNames({
               [classes.nonFullScreenStyles]: variant !== "full-screen",

--- a/features/auth/signup/FeedbackForm.tsx
+++ b/features/auth/signup/FeedbackForm.tsx
@@ -6,7 +6,9 @@ import { useAuthContext } from "features/auth/AuthProvider";
 import { Trans, useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import { ContributorForm as ContributorFormPb } from "proto/auth_pb";
+import TagManager from "react-gtm-module";
 import { service } from "service";
+import getRandomId from "utils/getRandomId";
 import isGrpcError from "utils/isGrpcError";
 
 export default function FeedbackForm() {
@@ -20,6 +22,14 @@ export default function FeedbackForm() {
         authState.flowState!.flowToken,
         form
       );
+      TagManager.dataLayer({
+        dataLayer: {
+          event: "sign_up",
+          signupMethod: "email",
+          userId: getRandomId(),
+          "gtm.elementUrl": `${window.location.hostname}${window.location.pathname}`,
+        },
+      });
       authActions.updateSignupState(res);
     } catch (err) {
       Sentry.captureException(err, {

--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -9,6 +9,7 @@ import { StatusCode } from "grpc-web";
 import mockRouter from "next-router-mock";
 import { HostingStatus } from "proto/api_pb";
 import { SignupFlowRes } from "proto/auth_pb";
+import TagManager from "react-gtm-module";
 import { dashboardRoute, signupRoute } from "routes";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
@@ -256,6 +257,16 @@ describe("Signup", () => {
 
     userEvent.click(screen.getByRole("button", { name: t("global:submit") }));
     await waitFor(() => expect(mockRouter.pathname).toBe(dashboardRoute));
+
+    expect(TagManager.dataLayer).toHaveBeenCalledTimes(1);
+    expect(TagManager.dataLayer).toHaveBeenCalledWith({
+      dataLayer: {
+        event: "sign_up",
+        signupMethod: "email",
+        userId: expect.any(String),
+        "gtm.elementUrl": expect.any(String),
+      },
+    });
   });
 
   it("displays the basic form if it is needed", async () => {

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -7,6 +7,7 @@ import "whatwg-fetch";
 
 //import * as Sentry from "@sentry/nextjs";
 import { waitFor } from "@testing-library/react";
+import crypto from "crypto";
 import mediaQuery from "css-mediaquery";
 import sentryTestkit from "sentry-testkit";
 import i18n from "test/i18n";
@@ -30,12 +31,20 @@ jest.mock("next/dynamic", () => ({
     } else throw Error(`Couldn't resolve dynamic component: ${matchedPath}`);
   },
 }));
+jest.mock("react-gtm-module");
 
 jest.setTimeout(15000);
 
 global.defaultUser = user;
 global.localStorage = createWebStorageMock();
 global.sessionStorage = createWebStorageMock();
+
+// @ts-expect-error Only interested in mocking getRandomValues
+global.crypto = {
+  getRandomValues(array: Uint32Array) {
+    return crypto.randomFillSync(array);
+  },
+};
 
 //sentry testing was causing OOM for some reason
 //const { testkit, sentryTransport } = sentryTestkit();

--- a/utils/getRandomId.ts
+++ b/utils/getRandomId.ts
@@ -1,0 +1,3 @@
+export default function getRandomId() {
+  return window.crypto.getRandomValues(new Uint32Array(1))[0].toString(16);
+}


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As described in title.

This came from a request from marketing, where they want to understand better sign up metrics. But since routing in the app doesn't cause a full refresh as in a traditional app, some extra code is needed to manually push some tracking data through.

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
