### PR TITLE
fix: friends and guest reference type labels swapped around

### DIFF
--- a/features/profile/constants.ts
+++ b/features/profile/constants.ts
@@ -29,18 +29,18 @@ export const referencesFilterLabels = (t: TFunction) => ({
   [ReferenceType.REFERENCE_TYPE_SURFED]: t(
     "profile:reference_filter_label.surfed"
   ),
-  all: "All references",
-  given: "Given to others",
+  all: t("profile:reference_filter_label.all"),
+  given: t("profile:reference_filter_label.given"),
 });
 export const referenceBadgeLabel = (t: TFunction) => ({
   [ReferenceType.REFERENCE_TYPE_FRIEND]: t(
-    "profile:reference_badge_label.surfed"
+    "profile:reference_badge_label.friend"
   ),
   [ReferenceType.REFERENCE_TYPE_HOSTED]: t(
     "profile:reference_badge_label.hosted"
   ),
   [ReferenceType.REFERENCE_TYPE_SURFED]: t(
-    "profile:reference_badge_label.friend"
+    "profile:reference_badge_label.surfed"
   ),
 });
 

--- a/features/profile/locales/en.json
+++ b/features/profile/locales/en.json
@@ -155,7 +155,9 @@
     "reference_filter_label": {
         "friend": "From friends",
         "hosted": "From hosts",
-        "surfed": "From guests"
+        "surfed": "From guests",
+        "given": "Given to others",
+        "all": "All references"
     },
     "reference_badge_label": {
         "friend": "Friend",

--- a/features/profile/view/References.test.tsx
+++ b/features/profile/view/References.test.tsx
@@ -13,7 +13,7 @@ import wrapper from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 import { MockedService, t } from "test/utils";
 
-import { referenceBadgeLabel, referencesFilterLabels } from "../constants";
+import { referenceBadgeLabel } from "../constants";
 import { ProfileUserProvider } from "../hooks/useProfileUser";
 import { REFERENCE_LIST_ITEM_TEST_ID } from "./ReferenceListItem";
 import References from "./References";
@@ -47,8 +47,13 @@ function renderReferences() {
   );
 }
 
-const [friendReference, guestReference1, guestReference2, givenReference] =
-  references;
+const [
+  friendReference,
+  guestReference1,
+  guestReference2,
+  givenReference,
+  hostReference,
+] = references;
 
 describe("References", () => {
   beforeEach(() => {
@@ -137,7 +142,7 @@ describe("References", () => {
       });
       userEvent.click(
         screen.getByRole("option", {
-          name: referencesFilterLabels(t)[ReferenceType.REFERENCE_TYPE_FRIEND],
+          name: t("profile:reference_filter_label.friend"),
         })
       );
 
@@ -150,9 +155,7 @@ describe("References", () => {
       ).toBeVisible();
       // Reference type badge
       expect(
-        reference.getByText(
-          referenceBadgeLabel(t)[ReferenceType.REFERENCE_TYPE_FRIEND]
-        )
+        reference.getByText(t("profile:reference_badge_label.friend"))
       ).toBeVisible();
       assertDateBadgeIsVisible(reference);
       expect(getReferencesReceivedMock).toHaveBeenCalledTimes(1);
@@ -170,7 +173,7 @@ describe("References", () => {
       });
       userEvent.click(
         screen.getByRole("option", {
-          name: referencesFilterLabels(t)[ReferenceType.REFERENCE_TYPE_SURFED],
+          name: t("profile:reference_filter_label.surfed"),
         })
       );
 
@@ -185,9 +188,7 @@ describe("References", () => {
         expect(reference.getByText(referencesList[i].text)).toBeVisible();
         // Reference type badge
         expect(
-          reference.getByText(
-            referenceBadgeLabel(t)[ReferenceType.REFERENCE_TYPE_SURFED]
-          )
+          reference.getByText(t("profile:reference_badge_label.surfed"))
         ).toBeVisible();
         assertDateBadgeIsVisible(reference);
       });
@@ -199,22 +200,29 @@ describe("References", () => {
       });
     });
 
-    // Since there aren't references from hosts in the fixture data
-    it("shows no references from hosts", async () => {
+    it("only shows references from hosts", async () => {
       getReferencesReceivedMock.mockResolvedValue({
         nextPageToken: "",
-        referencesList: [],
+        referencesList: [hostReference],
       });
       userEvent.click(
         screen.getByRole("option", {
-          name: referencesFilterLabels(t)[ReferenceType.REFERENCE_TYPE_HOSTED],
+          name: t("profile:reference_filter_label.hosted"),
         })
       );
 
-      expect(await screen.findByText(t("profile:no_references"))).toBeVisible();
+      const reference = within(
+        await screen.findByTestId(REFERENCE_LIST_ITEM_TEST_ID)
+      );
       expect(
-        screen.queryByTestId(REFERENCE_LIST_ITEM_TEST_ID)
-      ).not.toBeInTheDocument();
+        await screen.findByText(t("profile:reference_badge_label.hosted"))
+      ).toBeVisible();
+      expect(
+        reference.getByText(
+          "Hosting cat was a pleasure - there was never a dull moment!"
+        )
+      ).toBeVisible();
+      assertDateBadgeIsVisible(reference);
       expect(getReferencesReceivedMock).toHaveBeenCalledTimes(1);
       expect(getReferencesReceivedMock).toHaveBeenCalledWith({
         referenceType: ReferenceType.REFERENCE_TYPE_HOSTED,
@@ -228,7 +236,9 @@ describe("References", () => {
         referencesList: [givenReference],
       });
       userEvent.click(
-        screen.getByRole("option", { name: referencesFilterLabels(t)["given"] })
+        screen.getByRole("option", {
+          name: t("profile:reference_filter_label.given"),
+        })
       );
 
       const reference = within(
@@ -308,9 +318,7 @@ describe("References", () => {
         getReferencesReceivedMock.mockClear();
         userEvent.click(
           screen.getByRole("option", {
-            name: referencesFilterLabels(t)[
-              ReferenceType.REFERENCE_TYPE_FRIEND
-            ],
+            name: t("profile:reference_filter_label.friend"),
           })
         );
 

--- a/test/fixtures/references.json
+++ b/test/fixtures/references.json
@@ -46,5 +46,17 @@
       "nanos": 0
     },
     "hostRequestId": 3
+  },
+  {
+    "referenceId": 5,
+    "fromUserId": 4,
+    "toUserId": 1,
+    "referenceType": 2,
+    "text": "Hosting cat was a pleasure - there was never a dull moment!",
+    "writtenTime": {
+      "seconds": 1512544000,
+      "nanos": 0
+    },
+    "hostRequestId": 4
   }
 ]


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As in title, where the reference badge type was wrongly swapped around for friend and guest references.

Updated tests to make it actually catch mistakes by calling the t function with the expected translation key.

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
