### PR TITLE
port basic account creation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_COUCHERS_ENV=dev
-NEXT_PUBLIC_API_BASE_URL=https://api.couchers.dev
+NEXT_PUBLIC_API_BASE_URL=https://backend-v2-dev.couchers.dev/
 NEXT_PUBLIC_MEDIA_BASE_URL="https://media.couchers.dev"
 NEXT_PUBLIC_IS_POST_BETA_ENABLED=true
 NEXT_PUBLIC_MAPBOX_KEY="pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzY4eHd2MGVpcTJ0bGdhdGhvbHhlbiJ9.u5zvDeFE9H8itTK_dNp7Pg"

--- a/features/auth/locales/en.json
+++ b/features/auth/locales/en.json
@@ -82,15 +82,15 @@
     "tos_accept_label": "I Accept the Terms of Service."
   },
   "basic_form": {
-    "name": {
-      "field_label": "Your name",
-      "empty_error": "Please enter your name",
-      "required_error": "This field can't be empty."
-    },
     "email": {
       "field_label": "Email",
       "empty_error": "Please enter a valid email address",
       "required_error": "Email can't be empty."
+    },
+    "password": {
+      "field_label": "Password",
+      "empty_error": "Please enter a password",
+      "required_error": "Password can't be empty."
     }
   },
   "location": {

--- a/features/auth/locales/en.json
+++ b/features/auth/locales/en.json
@@ -89,7 +89,7 @@
     },
     "password": {
       "field_label": "Password",
-      "empty_error": "Please enter a password",
+      "empty_error": "Please enter a valid password",
       "required_error": "Password can't be empty."
     }
   },

--- a/features/auth/signup/BasicForm.test.tsx
+++ b/features/auth/signup/BasicForm.test.tsx
@@ -109,10 +109,10 @@ describe("basic signup form", () => {
 
   it("displays an error when present", async () => {
     createUserMock.mockRejectedValueOnce({
-      error_messages: {
+      errors: {
         email: ["A user with that email address already exists."],
       },
-      errors: ["The data submitted was invalid"],
+      error_messages: ["The data submitted was invalid"],
       status_code: 400,
     });
     render(<BasicForm />, {

--- a/features/auth/signup/BasicForm.test.tsx
+++ b/features/auth/signup/BasicForm.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import userEvent from "@testing-library/user-event";
-import { StatusCode } from "grpc-web";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import {

--- a/features/auth/signup/BasicForm.test.tsx
+++ b/features/auth/signup/BasicForm.test.tsx
@@ -16,17 +16,7 @@ import BasicForm from "./BasicForm";
 
 const createUserMock = service.auth.createUser as MockedService<
   typeof service.auth.createUser
->
-
-const stateAfterStart = {
-  flowToken: "dummy-token",
-  success: false,
-  needBasic: false,
-  needAccount: false,
-  needAcceptCommunityGuidelines: true,
-  needFeedback: true,
-  needVerifyEmail: true,
-};
+>;
 
 describe("basic signup form", () => {
   it("cannot be submitted empty", async () => {
@@ -53,10 +43,7 @@ describe("basic signup form", () => {
     expect(result.current.authState.flowState).toBe(null);
 
     render(<BasicForm />, { wrapper });
-    userEvent.type(
-      await screen.findByLabelText("Password"),
-      "P@ssword123 "
-    );
+    userEvent.type(await screen.findByLabelText("Password"), "P@ssword123");
     userEvent.click(
       await screen.findByRole("button", { name: t("global:continue") })
     );
@@ -95,7 +82,7 @@ describe("basic signup form", () => {
     createUserMock.mockResolvedValue({
       email: "frodo@couchers.org.invalid",
       username: "frodo@couchers.org.invalid",
-      id :1
+      id: 1,
     });
     const { result } = renderHook(() => useAuthContext(), { wrapper });
     expect(result.current.authState.authenticated).toBe(false);
@@ -106,10 +93,7 @@ describe("basic signup form", () => {
       await screen.findByLabelText(t("auth:basic_form.email.field_label")),
       "frodo@couchers.org.invalid"
     );
-    userEvent.type(
-      await screen.findByLabelText("Password"),
-      "P@ssword123"
-    );
+    userEvent.type(await screen.findByLabelText("Password"), "P@ssword123");
 
     userEvent.click(
       await screen.findByRole("button", { name: t("global:continue") })
@@ -127,10 +111,10 @@ describe("basic signup form", () => {
   it("displays an error when present", async () => {
     createUserMock.mockRejectedValueOnce({
       error_messages: {
-        email: ["A user with that email address already exists."]
+        email: ["A user with that email address already exists."],
       },
       errors: ["The data submitted was invalid"],
-      status_code: 400
+      status_code: 400,
     });
     render(<BasicForm />, {
       wrapper,
@@ -140,10 +124,7 @@ describe("basic signup form", () => {
       screen.getByLabelText(t("auth:basic_form.email.field_label")),
       "test@example.com{enter}"
     );
-    userEvent.type(
-      screen.getByLabelText("Password"),
-      "P@ssword123"
-    );
+    userEvent.type(screen.getByLabelText("Password"), "P@ssword123");
     mockConsoleError();
     await assertErrorAlert("A user with that email address already exists.");
   });

--- a/features/auth/signup/BasicForm.tsx
+++ b/features/auth/signup/BasicForm.tsx
@@ -117,7 +117,7 @@ export default function BasicForm({
               message: t("auth:basic_form.password.empty_error"),
               value: passwordValidationPattern,
             },
-            required: t("auth:basic_form.email.required_error"),
+            required: t("auth:basic_form.password.required_error"),
           })}
           helperText={errors?.password?.message ?? " "}
           error={!!errors?.password?.message}

--- a/features/auth/signup/BasicForm.tsx
+++ b/features/auth/signup/BasicForm.tsx
@@ -13,7 +13,7 @@ import { HttpError } from "service/auth"
 import {
   emailValidationPattern,
   lowercaseAndTrimField,
-  passwordValidationPatern
+  passwordValidationPattern
 } from "utils/validation";
 
 type SignupBasicInputs = {
@@ -110,10 +110,10 @@ export default function BasicForm({
           variant="standard"
           inputRef={register({
             pattern: {
-              message: "Please enter a password",
-              value: passwordValidationPatern,
+              message: t("auth:basic_form.password.empty_error"),
+              value: passwordValidationPattern,
             },
-            required: "Password can't be empty.",
+            required: t("auth:basic_form.email.required_error"),
           })}
           helperText={errors?.password?.message ?? " "}
           error={!!errors?.password?.message}

--- a/features/auth/signup/BasicForm.tsx
+++ b/features/auth/signup/BasicForm.tsx
@@ -9,11 +9,11 @@ import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
-import { HttpError } from "service/auth"
+import { HttpError } from "service/auth";
 import {
   emailValidationPattern,
   lowercaseAndTrimField,
-  passwordValidationPattern
+  passwordValidationPattern,
 } from "utils/validation";
 
 type SignupBasicInputs = {
@@ -42,17 +42,17 @@ export default function BasicForm({
   const mutation = useMutation<void, HttpError, SignupBasicInputs>(
     async (data) => {
       const sanitizedEmail = lowercaseAndTrimField(data.email);
-      const { password } = data
+      const { password } = data;
       // TODO - persist the user id returned from in the createUser response
-      await service.auth.createUser(sanitizedEmail, sanitizedEmail, password)
+      await service.auth.createUser(sanitizedEmail, sanitizedEmail, password);
       const authState = {
         flowToken: "",
         needBasic: false,
         needAccount: true,
         needFeedback: true,
         needVerifyEmail: true,
-        needAcceptCommunityGuidelines: true, 
-      }
+        needAcceptCommunityGuidelines: true,
+      };
       return authActions.updateSignupState(authState);
     },
     {
@@ -71,9 +71,13 @@ export default function BasicForm({
     mutation.mutate(data);
   });
 
-  const formSubmitErrors = Object.entries(mutation.error?.error_messages || {}).map(([field, message]) => (
-    <Alert severity="error" key={field}>{message}</Alert>
-  ))
+  const formSubmitErrors = Object.entries(
+    mutation.error?.error_messages || {}
+  ).map(([field, message]) => (
+    <Alert severity="error" key={field}>
+      {message}
+    </Alert>
+  ));
 
   return (
     <>

--- a/features/auth/signup/BasicForm.tsx
+++ b/features/auth/signup/BasicForm.tsx
@@ -71,10 +71,11 @@ export default function BasicForm({
     mutation.mutate(data);
   });
 
-  const formSubmitErrors = Object.entries(
-    mutation.error?.error_messages || {}
-  ).map(([field, message]) => (
-    <Alert severity="error" key={field}>
+  const formSubmitErrors = Object.values(
+    mutation.error?.errors || {}
+  ).flat()
+  .map(message => (
+    <Alert severity="error" key={message}>
       {message}
     </Alert>
   ));

--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -24,6 +24,9 @@ import Signup from "./Signup";
 const startSignupMock = service.auth.startSignup as MockedService<
   typeof service.auth.startSignup
 >;
+const createUserMock = service.auth.createUser as MockedService<
+  typeof service.auth.createUser
+>
 const signupFlowAccountMock = service.auth.signupFlowAccount as MockedService<
   typeof service.auth.signupFlowAccount
 >;
@@ -98,24 +101,21 @@ describe("Signup", () => {
           needVerifyEmail: false,
         })
       );
-      startSignupMock.mockResolvedValue({
-        flowToken: "token",
-        needBasic: false,
-        needAccount: true,
-        needAcceptCommunityGuidelines: true,
-        needFeedback: true,
-        needVerifyEmail: false,
+      createUserMock.mockResolvedValue({
+        email: "test@example.com",
+        username: "Test user",
+        id: 1,
       });
 
       render(<View />, { wrapper });
 
       userEvent.type(
-        await screen.findByLabelText(t("auth:basic_form.name.field_label")),
-        "Test user"
+        screen.getByLabelText(t("auth:basic_form.email.field_label")),
+        "test@example.com"
       );
       userEvent.type(
-        screen.getByLabelText(t("auth:basic_form.email.field_label")),
-        "test@example.com{enter}"
+        screen.getByLabelText("Password"),
+        "Password123{enter}"
       );
       expect(
         await screen.findByLabelText(

--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -26,7 +26,7 @@ const startSignupMock = service.auth.startSignup as MockedService<
 >;
 const createUserMock = service.auth.createUser as MockedService<
   typeof service.auth.createUser
->
+>;
 const signupFlowAccountMock = service.auth.signupFlowAccount as MockedService<
   typeof service.auth.signupFlowAccount
 >;
@@ -113,10 +113,7 @@ describe("Signup", () => {
         screen.getByLabelText(t("auth:basic_form.email.field_label")),
         "test@example.com"
       );
-      userEvent.type(
-        screen.getByLabelText("Password"),
-        "Password123{enter}"
-      );
+      userEvent.type(screen.getByLabelText("Password"), "Password123{enter}");
       expect(
         await screen.findByLabelText(
           t("auth:account_form.username.field_label")

--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -21,9 +21,6 @@ import {
 
 import Signup from "./Signup";
 
-const startSignupMock = service.auth.startSignup as MockedService<
-  typeof service.auth.startSignup
->;
 const createUserMock = service.auth.createUser as MockedService<
   typeof service.auth.createUser
 >;

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -13,6 +13,30 @@ import {
 } from "proto/auth_pb";
 import client from "service/client";
 
+type CreateUserReq = {
+  email: string,
+  username: string,
+  password: string
+}
+
+type CreateUserRes = {
+  email: string,
+  username: string,
+  id: number
+}
+
+export type HttpError = {
+  status_code: number,
+  errors: [string],
+  error_messages: {
+    [key: string]: string
+  }
+}
+
+export async function createUser(username: string, email: string, password: string){
+  return client.post<CreateUserReq, CreateUserRes>("users/", { username, email, password })
+}
+
 export async function checkUsername(username: string) {
   const req = new LoginReq();
   req.setUser(username);

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -13,21 +13,21 @@ import {
 } from "proto/auth_pb";
 import client from "service/client";
 
-type CreateUserReq = {
+interface CreateUserReq {
   email: string,
   username: string,
   password: string
 }
 
-type CreateUserRes = {
+interface CreateUserRes {
   email: string,
   username: string,
   id: number
 }
 
-export type HttpError = {
+export interface HttpError {
   status_code: number,
-  errors: [string],
+  errors: string[],
   error_messages: {
     [key: string]: string
   }

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -27,9 +27,9 @@ interface CreateUserRes {
 
 export interface HttpError {
   status_code: number;
-  errors: string[];
-  error_messages: {
-    [key: string]: string;
+  error_messages: string[];
+  errors?: {
+    [key: string]: string[];
   };
 }
 

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -14,27 +14,35 @@ import {
 import client from "service/client";
 
 interface CreateUserReq {
-  email: string,
-  username: string,
-  password: string
+  email: string;
+  username: string;
+  password: string;
 }
 
 interface CreateUserRes {
-  email: string,
-  username: string,
-  id: number
+  email: string;
+  username: string;
+  id: number;
 }
 
 export interface HttpError {
-  status_code: number,
-  errors: string[],
+  status_code: number;
+  errors: string[];
   error_messages: {
-    [key: string]: string
-  }
+    [key: string]: string;
+  };
 }
 
-export async function createUser(username: string, email: string, password: string){
-  return client.post<CreateUserReq, CreateUserRes>("users/", { username, email, password })
+export async function createUser(
+  username: string,
+  email: string,
+  password: string
+) {
+  return client.post<CreateUserReq, CreateUserRes>("users/", {
+    username,
+    email,
+    password,
+  });
 }
 
 export async function checkUsername(username: string) {

--- a/service/client.ts
+++ b/service/client.ts
@@ -21,7 +21,7 @@ import { SearchPromiseClient } from "proto/search_grpc_web_pb";
 import { ThreadsPromiseClient } from "proto/threads_grpc_web_pb";
 import isGrpcError from "utils/isGrpcError";
 
-import { get, post, put} from "./http"
+import { get, post, put } from "./http";
 
 const URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -95,7 +95,7 @@ const client = {
   threads: new ThreadsPromiseClient(URL, null, opts),
   get,
   post,
-  put
+  put,
 };
 
 if (

--- a/service/client.ts
+++ b/service/client.ts
@@ -1,6 +1,5 @@
 import { grpcTimeout } from "appConstants";
 import { Request as RpcRequest, RpcError, StatusCode } from "grpc-web";
-import path from "path"
 import { AccountPromiseClient } from "proto/account_grpc_web_pb";
 import { APIPromiseClient } from "proto/api_grpc_web_pb";
 import { AuthPromiseClient } from "proto/auth_grpc_web_pb";
@@ -22,43 +21,9 @@ import { SearchPromiseClient } from "proto/search_grpc_web_pb";
 import { ThreadsPromiseClient } from "proto/threads_grpc_web_pb";
 import isGrpcError from "utils/isGrpcError";
 
+import { get, post, put} from "./http"
+
 const URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-async function http<T>(endpoint: string, configOverride: RequestInit): Promise<T> {
-  const url = path.join(URL, endpoint)
-  const config = {
-    headers: {
-      "content-type": "application/json"
-    },
-    ...configOverride
-  }
-  const request = new Request(url, config)
-  const response = await fetch(request)
-
-  // if(!response.ok) {
-  //   throw new Error(response.statusText)
-  // }
-
-  // may error if there is no body, return empty array
-  return response.json().catch(() => ({}))
-}
-
-export async function get<T>(path: string, config?: RequestInit): Promise<T> {
-  const init = {method: 'get', ...config}
-  return await http<T>(path, init)
-}
-
-export async function post<T, U>(path: string, body: T, config?: RequestInit): Promise<U> {
-  const init = {method: 'post', body: JSON.stringify(body), ...config}
-  return await http<U>(path, init)
-}
-
-export async function put<T, U>(path: string, body: T, config?: RequestInit): Promise<U> {
-  const init = {method: 'put', body: JSON.stringify(body), ...config}
-  return await http<U>(path, init)
-}
-
-// TODO - deprecate below vvv
 
 let _unauthenticatedErrorHandler: (
   e: RpcError
@@ -109,11 +74,6 @@ const opts = {
 };
 
 const client = {
-  // new http client
-  get,
-  post,
-  put,
-  // TODO - depreacte rest of object
   account: new AccountPromiseClient(URL, null, opts),
   api: new APIPromiseClient(URL, null, opts),
   auth: new AuthPromiseClient(URL, null, opts),
@@ -133,6 +93,9 @@ const client = {
   resources: new ResourcesPromiseClient(URL, null, opts),
   search: new SearchPromiseClient(URL, null, opts),
   threads: new ThreadsPromiseClient(URL, null, opts),
+  get,
+  post,
+  put
 };
 
 if (

--- a/service/client.ts
+++ b/service/client.ts
@@ -1,5 +1,6 @@
 import { grpcTimeout } from "appConstants";
-import { Request, RpcError, StatusCode } from "grpc-web";
+import { Request as RpcRequest, RpcError, StatusCode } from "grpc-web";
+import path from "path"
 import { AccountPromiseClient } from "proto/account_grpc_web_pb";
 import { APIPromiseClient } from "proto/api_grpc_web_pb";
 import { AuthPromiseClient } from "proto/auth_grpc_web_pb";
@@ -22,6 +23,42 @@ import { ThreadsPromiseClient } from "proto/threads_grpc_web_pb";
 import isGrpcError from "utils/isGrpcError";
 
 const URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function http<T>(endpoint: string, configOverride: RequestInit): Promise<T> {
+  const url = path.join(URL, endpoint)
+  const config = {
+    headers: {
+      "content-type": "application/json"
+    },
+    ...configOverride
+  }
+  const request = new Request(url, config)
+  const response = await fetch(request)
+
+  // if(!response.ok) {
+  //   throw new Error(response.statusText)
+  // }
+
+  // may error if there is no body, return empty array
+  return response.json().catch(() => ({}))
+}
+
+export async function get<T>(path: string, config?: RequestInit): Promise<T> {
+  const init = {method: 'get', ...config}
+  return await http<T>(path, init)
+}
+
+export async function post<T, U>(path: string, body: T, config?: RequestInit): Promise<U> {
+  const init = {method: 'post', body: JSON.stringify(body), ...config}
+  return await http<U>(path, init)
+}
+
+export async function put<T, U>(path: string, body: T, config?: RequestInit): Promise<U> {
+  const init = {method: 'put', body: JSON.stringify(body), ...config}
+  return await http<U>(path, init)
+}
+
+// TODO - deprecate below vvv
 
 let _unauthenticatedErrorHandler: (
   e: RpcError
@@ -50,7 +87,7 @@ export class AuthInterceptor {
 
 class TimeoutInterceptor {
   async intercept(
-    request: Request<unknown, unknown>,
+    request: RpcRequest<unknown, unknown>,
     invoker: (request: unknown) => unknown
   ) {
     const deadline = Date.now() + grpcTimeout;
@@ -72,6 +109,11 @@ const opts = {
 };
 
 const client = {
+  // new http client
+  get,
+  post,
+  put,
+  // TODO - depreacte rest of object
   account: new AccountPromiseClient(URL, null, opts),
   api: new APIPromiseClient(URL, null, opts),
   auth: new AuthPromiseClient(URL, null, opts),

--- a/service/http.ts
+++ b/service/http.ts
@@ -1,30 +1,41 @@
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-async function http<T>(endpoint: string, configOverride: RequestInit): Promise<T> {
-  const url = new URL(endpoint, API_URL).toString()
+async function http<T>(
+  endpoint: string,
+  configOverride: RequestInit
+): Promise<T> {
+  const url = new URL(endpoint, API_URL).toString();
   const config = {
     headers: {
-      "content-type": "application/json"
+      "content-type": "application/json",
     },
-    ...configOverride
-  }
-  const request = new Request(url, config)
-  const response = await fetch(request)
+    ...configOverride,
+  };
+  const request = new Request(url, config);
+  const response = await fetch(request);
 
-  return response.json().catch(() => ({}))
+  return response.json().catch(() => ({}));
 }
 
 export async function get<T>(path: string, config?: RequestInit): Promise<T> {
-  const init = {method: 'get', ...config}
-  return await http<T>(path, init)
+  const init = { method: "get", ...config };
+  return await http<T>(path, init);
 }
 
-export async function post<T, U>(path: string, body: T, config?: Omit<RequestInit, 'body'>): Promise<U> {
-  const init = {method: 'post', body: JSON.stringify(body), ...config}
-  return await http<U>(path, init)
+export async function post<T, U>(
+  path: string,
+  body: T,
+  config?: Omit<RequestInit, "body">
+): Promise<U> {
+  const init = { method: "post", body: JSON.stringify(body), ...config };
+  return await http<U>(path, init);
 }
 
-export async function put<T, U>(path: string, body: T, config?: Omit<RequestInit, 'body'>): Promise<U> {
-  const init = {method: 'put', body: JSON.stringify(body), ...config}
-  return await http<U>(path, init)
+export async function put<T, U>(
+  path: string,
+  body: T,
+  config?: Omit<RequestInit, "body">
+): Promise<U> {
+  const init = { method: "put", body: JSON.stringify(body), ...config };
+  return await http<U>(path, init);
 }

--- a/service/http.ts
+++ b/service/http.ts
@@ -1,0 +1,30 @@
+const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function http<T>(endpoint: string, configOverride: RequestInit): Promise<T> {
+  const url = new URL(endpoint, API_URL).toString()
+  const config = {
+    headers: {
+      "content-type": "application/json"
+    },
+    ...configOverride
+  }
+  const request = new Request(url, config)
+  const response = await fetch(request)
+
+  return response.json().catch(() => ({}))
+}
+
+export async function get<T>(path: string, config?: RequestInit): Promise<T> {
+  const init = {method: 'get', ...config}
+  return await http<T>(path, init)
+}
+
+export async function post<T, U>(path: string, body: T, config?: Omit<RequestInit, 'body'>): Promise<U> {
+  const init = {method: 'post', body: JSON.stringify(body), ...config}
+  return await http<U>(path, init)
+}
+
+export async function put<T, U>(path: string, body: T, config?: Omit<RequestInit, 'body'>): Promise<U> {
+  const init = {method: 'put', body: JSON.stringify(body), ...config}
+  return await http<U>(path, init)
+}

--- a/service/user.ts
+++ b/service/user.ts
@@ -93,7 +93,7 @@ export async function getCurrentUser(): Promise<User.AsObject> {
  * @param {string} user
  * @returns {Promise<User.AsObject>}
  */
- export async function getUser(user: string): Promise<User.AsObject> {
+export async function getUser(user: string): Promise<User.AsObject> {
   const userReq = new GetUserReq();
   userReq.setUser(user || "");
 

--- a/service/user.ts
+++ b/service/user.ts
@@ -93,14 +93,18 @@ export async function getCurrentUser(): Promise<User.AsObject> {
  * @param {string} user
  * @returns {Promise<User.AsObject>}
  */
-export async function getUser(user: string): Promise<User.AsObject> {
-  const userReq = new GetUserReq();
-  userReq.setUser(user || "");
-
-  const response = await client.api.getUser(userReq);
-
-  return response.toObject();
+export async function getUser(user: string): Promise<User.AsObject>{
+  console.log("getUser", user)
+  return new Promise((res, rej) => rej())
 }
+// export async function getUser(user: string): Promise<User.AsObject> {
+//   const userReq = new GetUserReq();
+//   userReq.setUser(user || "");
+
+//   const response = await client.api.getUser(userReq);
+
+//   return response.toObject();
+// }
 
 /**
  * Updates user profile

--- a/service/user.ts
+++ b/service/user.ts
@@ -93,18 +93,14 @@ export async function getCurrentUser(): Promise<User.AsObject> {
  * @param {string} user
  * @returns {Promise<User.AsObject>}
  */
-export async function getUser(user: string): Promise<User.AsObject>{
-  console.log("getUser", user)
-  return new Promise((res, rej) => rej())
+ export async function getUser(user: string): Promise<User.AsObject> {
+  const userReq = new GetUserReq();
+  userReq.setUser(user || "");
+
+  const response = await client.api.getUser(userReq);
+
+  return response.toObject();
 }
-// export async function getUser(user: string): Promise<User.AsObject> {
-//   const userReq = new GetUserReq();
-//   userReq.setUser(user || "");
-
-//   const response = await client.api.getUser(userReq);
-
-//   return response.toObject();
-// }
 
 /**
  * Updates user profile

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,7 +1,7 @@
 // taken from backend
 export const nameValidationPattern = /\S+/;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
-export const passwordValidationPattern = /.{8,255}/
+export const passwordValidationPattern = /.{8,255}/;
 export const validatePassword = (password: string) => {
   return password.length >= 8 && password.length < 256;
 };

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,7 +1,7 @@
 // taken from backend
 export const nameValidationPattern = /\S+/;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
-export const passwordValidationPatern = /.{8,255}/
+export const passwordValidationPattern = /.{8,255}/
 export const validatePassword = (password: string) => {
   return password.length >= 8 && password.length < 256;
 };

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,6 +1,7 @@
 // taken from backend
 export const nameValidationPattern = /\S+/;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
+export const passwordValidationPatern = /.{8,255}/
 export const validatePassword = (password: string) => {
   return password.length >= 8 && password.length < 256;
 };


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Part of #227 

This is porting basic account creation to new backend REST API. The expected behaviour for now is to get an activation email when you create a new user, nothing else yet!

In order to use the new API the form has changed to require email + password to create an account:

<img width="1440" alt="Screen Shot 2022-10-11 at 5 40 25 PM" src="https://user-images.githubusercontent.com/12486723/195211449-51a1a2bf-6574-4cf6-a6e7-0128bcda2f55.png">

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
