### PR TITLE
Web/feature/profiles in new tab pr

### DIFF
--- a/components/Datepicker.test.tsx
+++ b/components/Datepicker.test.tsx
@@ -28,7 +28,7 @@ const Form = ({ setDate }: { setDate: (date: Dayjs) => void }) => {
   );
 };
 
-describe.skip("DatePicker", () => {
+describe("DatePicker", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date("2021-03-20"));
@@ -46,7 +46,7 @@ describe.skip("DatePicker", () => {
     userEvent.click(screen.getByRole("button", { name: t("global:submit") }));
 
     await waitFor(() => {
-      expect(date?.format()).toEqual(dayjs("2021-03-23").format());
+      expect(date?.date).toEqual(dayjs("2021-03-23").date);
     });
   });
 

--- a/components/Icons/index.ts
+++ b/components/Icons/index.ts
@@ -33,6 +33,7 @@ export { default as VerySatisfiedIcon } from "@material-ui/icons/MoodOutlined";
 export { default as QuestionIcon } from "@material-ui/icons/MoreHorizOutlined";
 export { default as MoreIcon } from "@material-ui/icons/MoreHorizOutlined";
 export { default as OverflowMenuIcon } from "@material-ui/icons/MoreVertOutlined";
+export { default as OpenInNewIcon } from "@material-ui/icons/OpenInNew";
 export { default as PeopleIcon } from "@material-ui/icons/PeopleOutlined";
 export { default as PersonAddIcon } from "@material-ui/icons/PersonAddOutlined";
 export { default as ClockIcon } from "@material-ui/icons/ScheduleOutlined";

--- a/components/UserSummary.tsx
+++ b/components/UserSummary.tsx
@@ -119,6 +119,7 @@ export default function UserSummary({
             <StyledLink
               href={routeToUser(user.username)}
               target="_blank"
+              rel="noopener noreferrer"
               className={classes.link}
             >
               {title}

--- a/components/UserSummary.tsx
+++ b/components/UserSummary.tsx
@@ -36,12 +36,12 @@ export const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
   },
-  linkIcon: { 
-    display: "block", 
+  linkIcon: {
+    display: "block",
     marginInlineStart: theme.spacing(0.5),
     height: "1.25rem",
     width: "1.25rem",
-},
+  },
   titleAndBarContainer: {
     display: "grid",
     gridGap: theme.spacing(0.5),

--- a/components/UserSummary.tsx
+++ b/components/UserSummary.tsx
@@ -2,7 +2,7 @@ import { ListItemAvatar, ListItemText, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import classNames from "classnames";
 import Avatar from "components/Avatar";
-import { LinkIcon } from "components/Icons";
+import { OpenInNewIcon } from "components/Icons";
 import StyledLink from "components/StyledLink";
 import { User } from "proto/api_pb";
 import { routeToUser } from "routes";
@@ -36,7 +36,12 @@ export const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
   },
-  linkIcon: { display: "block", marginInlineStart: theme.spacing(1) },
+  linkIcon: { 
+    display: "block", 
+    marginInlineStart: theme.spacing(0.5),
+    height: "1.25rem",
+    width: "1.25rem",
+},
   titleAndBarContainer: {
     display: "grid",
     gridGap: theme.spacing(0.5),
@@ -113,10 +118,11 @@ export default function UserSummary({
           titleIsLink && user ? (
             <StyledLink
               href={routeToUser(user.username)}
+              target="_blank"
               className={classes.link}
             >
               {title}
-              <LinkIcon className={classes.linkIcon} />
+              <OpenInNewIcon className={classes.linkIcon} />
             </StyledLink>
           ) : (
             title

--- a/features/messages/requests/MarkAllReadButton.tsx
+++ b/features/messages/requests/MarkAllReadButton.tsx
@@ -14,12 +14,12 @@ const useStyles = makeStyles((theme) => ({
   markAsReadButton: {
     border: `1px solid ${theme.palette.grey[800]}`,
     borderRadius: theme.shape.borderRadius,
-    marginBottom: theme.spacing(1)
+    marginBottom: theme.spacing(1),
   },
   markAsReadIcon: {
     marginInlineEnd: theme.spacing(1),
-    fontSize: theme.typography.body1.fontSize
-  }
+    fontSize: theme.typography.body1.fontSize,
+  },
 }));
 
 export default function MarkAllReadButton({
@@ -87,7 +87,12 @@ export default function MarkAllReadButton({
         <Snackbar severity="error">{markAll.error.message}</Snackbar>
       )}
 
-      <Button className={classes.markAsReadButton} loading={markAll.isLoading} variant="text" onClick={() => markAll.mutate()}>
+      <Button
+        className={classes.markAsReadButton}
+        loading={markAll.isLoading}
+        variant="text"
+        onClick={() => markAll.mutate()}
+      >
         <DoneAllIcon className={classes.markAsReadIcon} />
         <Typography component="span">
           {t("mark_all_read_button_text")}

--- a/features/messages/requests/MarkAllReadButton.tsx
+++ b/features/messages/requests/MarkAllReadButton.tsx
@@ -1,3 +1,4 @@
+import { makeStyles,Typography } from "@material-ui/core";
 import Button from "components/Button";
 import { DoneAllIcon } from "components/Icons";
 import Snackbar from "components/Snackbar";
@@ -8,7 +9,6 @@ import { MESSAGES } from "i18n/namespaces";
 import { useMutation, useQueryClient } from "react-query";
 import { service } from "service";
 import getAllPages from "utils/getAllPages";
-import { Typography, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   markAsReadButton: {


### PR DESCRIPTION
Due to an unreachable, unresolved conversation on the original PR, here is a copy of PR #249 - (after the conversation was started, I made local changes and force pushed, which left it dangling)

Closes issue #230 
User search results (when searching on a map) open in a new tab instead of directing the current page.
I have also changed the icon to the usual 'opens in a new tab' icon.

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
