### PR TITLE
Allow signup flow to be resumed from email token

### DIFF
--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -35,6 +35,9 @@ const signupFlowFeedbackMock = service.auth.signupFlowFeedback as MockedService<
 const validateUsernameMock = service.auth.validateUsername as MockedService<
   typeof service.auth.validateUsername
 >;
+const getSignupFlowMock = service.auth.getSignupFlow as MockedService<
+  typeof service.auth.getSignupFlow
+>;
 
 const View = () => {
   return <Signup />;
@@ -350,5 +353,31 @@ describe("Signup", () => {
     window.localStorage.setItem("auth.authenticated", "true");
     render(<View />, { wrapper });
     await waitFor(() => expect(mockRouter.pathname).toBe(dashboardRoute));
+  });
+
+  it("restores state from signup token", async () => {
+    mockRouter.setCurrentUrl(`${signupRoute}?token=test-token`);
+    getSignupFlowMock.mockResolvedValue({
+      flow_token: "test-token",
+      account_is_filled: true,
+    });
+
+    render(<View />, { wrapper });
+
+    expect(
+      await screen.findByText(t("auth:community_guidelines_form.header"))
+    ).toBeVisible();
+  });
+
+  it("handles bad signup token", async () => {
+    mockRouter.setCurrentUrl(`${signupRoute}?token=bad-token`);
+    getSignupFlowMock.mockRejectedValue({
+      error_messages: ["Invalid token"],
+      status_code: 400,
+    });
+
+    render(<View />, { wrapper });
+
+    await waitFor(() => expect(mockRouter.pathname).toBe(loginRoute));
   });
 });

--- a/features/auth/signup/Signup.test.tsx
+++ b/features/auth/signup/Signup.test.tsx
@@ -178,144 +178,144 @@ describe("Signup", () => {
         expect(screen.getByText(QUESTIONS_OPTIONAL)).toBeVisible();
       });
     });
-  });
 
-  it("contributor form -> success", async () => {
-    jest.spyOn(console, "warn").mockImplementation(undefined);
-    window.localStorage.setItem(
-      "auth.flowState",
-      JSON.stringify({
+    it("contributor form -> success", async () => {
+      jest.spyOn(console, "warn").mockImplementation(undefined);
+      window.localStorage.setItem(
+        "auth.flowState",
+        JSON.stringify({
+          flowToken: "token",
+          needAccount: false,
+          needAcceptCommunityGuidelines: false,
+          needFeedback: true,
+        })
+      );
+      signupFlowFeedbackMock.mockResolvedValue({
+        flow_token: "token",
+        user_created: true,
+        account_is_filled: true,
+        accepted_current_community_guidelines: true,
+        filled_feedback: true,
+      });
+
+      render(<View />, { wrapper });
+
+      userEvent.click(screen.getByRole("button", { name: t("global:submit") }));
+      await waitFor(() => expect(mockRouter.pathname).toBe(loginRoute));
+
+      expect(TagManager.dataLayer).toHaveBeenCalledTimes(1);
+      expect(TagManager.dataLayer).toHaveBeenCalledWith({
+        dataLayer: {
+          event: "sign_up",
+          signupMethod: "email",
+          userId: expect.any(String),
+          "gtm.elementUrl": expect.any(String),
+        },
+      });
+    });
+
+    it("displays the account form when account, feedback, and guidelines pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
+        needAccount: true,
+        needFeedback: true,
+        needAcceptCommunityGuidelines: true,
         flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        screen.getByLabelText(t("auth:account_form.username.field_label"))
+      ).toBeVisible();
+    });
+
+    it("displays the account form when account and guidelines are pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
+        needAccount: true,
+        needAcceptCommunityGuidelines: true,
+        needFeedback: false,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        screen.getByLabelText(t("auth:account_form.username.field_label"))
+      ).toBeVisible();
+    });
+
+    it("displays the account form when only account is pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
+        needAccount: true,
+        needAcceptCommunityGuidelines: false,
+        needFeedback: false,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        screen.getByLabelText(t("auth:account_form.username.field_label"))
+      ).toBeVisible();
+    });
+
+    it("displays the guidelines form when guidelines and feedback are pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
+        needAccount: false,
+        needAcceptCommunityGuidelines: true,
+        needFeedback: true,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        await screen.findByText(t("auth:community_guidelines_form.header"))
+      ).toBeVisible();
+    });
+
+    it("displays the guidelines form when only it and feedback are pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
+        needAccount: false,
+        needAcceptCommunityGuidelines: true,
+        needFeedback: true,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        await screen.findByText(t("auth:community_guidelines_form.header"))
+      ).toBeVisible();
+    });
+
+    it("displays the feedback form when feedback is pending", async () => {
+      const state: SignupFlow = {
+        isCompleted: false,
         needAccount: false,
         needAcceptCommunityGuidelines: false,
         needFeedback: true,
-      })
-    );
-    signupFlowFeedbackMock.mockResolvedValue({
-      flow_token: "token",
-      user_created: true,
-      account_is_filled: true,
-      accepted_current_community_guidelines: true,
-      filled_feedback: true,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(screen.getByText(QUESTIONS_OPTIONAL)).toBeVisible();
     });
 
-    render(<View />, { wrapper });
-
-    userEvent.click(screen.getByRole("button", { name: t("global:submit") }));
-    await waitFor(() => expect(mockRouter.pathname).toBe(loginRoute));
-
-    expect(TagManager.dataLayer).toHaveBeenCalledTimes(1);
-    expect(TagManager.dataLayer).toHaveBeenCalledWith({
-      dataLayer: {
-        event: "sign_up",
-        signupMethod: "email",
-        userId: expect.any(String),
-        "gtm.elementUrl": expect.any(String),
-      },
+    it("displays the redirect message when signup is complete", async () => {
+      const state: SignupFlow = {
+        isCompleted: true,
+        needAccount: false,
+        needAcceptCommunityGuidelines: false,
+        needFeedback: false,
+        flowToken: "token",
+      };
+      window.localStorage.setItem("auth.flowState", JSON.stringify(state));
+      render(<View />, { wrapper });
+      expect(
+        await screen.findByText(t("auth:sign_up_confirmed_prompt"))
+      ).toBeVisible();
     });
-  });
-
-  it("displays the account form when account, feedback, and guidelines pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: true,
-      needFeedback: true,
-      needAcceptCommunityGuidelines: true,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      screen.getByLabelText(t("auth:account_form.username.field_label"))
-    ).toBeVisible();
-  });
-
-  it("displays the account form when account and guidelines are pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: true,
-      needAcceptCommunityGuidelines: true,
-      needFeedback: false,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      screen.getByLabelText(t("auth:account_form.username.field_label"))
-    ).toBeVisible();
-  });
-
-  it("displays the account form when only account is pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: true,
-      needAcceptCommunityGuidelines: false,
-      needFeedback: false,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      screen.getByLabelText(t("auth:account_form.username.field_label"))
-    ).toBeVisible();
-  });
-
-  it("displays the guidelines form when guidelines and feedback are pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: false,
-      needAcceptCommunityGuidelines: true,
-      needFeedback: true,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      await screen.findByText(t("auth:community_guidelines_form.header"))
-    ).toBeVisible();
-  });
-
-  it("displays the guidelines form when only it and feedback are pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: false,
-      needAcceptCommunityGuidelines: true,
-      needFeedback: true,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      await screen.findByText(t("auth:community_guidelines_form.header"))
-    ).toBeVisible();
-  });
-
-  it("displays the feedback form when feedback is pending", async () => {
-    const state: SignupFlow = {
-      isCompleted: false,
-      needAccount: false,
-      needAcceptCommunityGuidelines: false,
-      needFeedback: true,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(screen.getByText(QUESTIONS_OPTIONAL)).toBeVisible();
-  });
-
-  it("displays the redirect message when signup is complete", async () => {
-    const state: SignupFlow = {
-      isCompleted: true,
-      needAccount: false,
-      needAcceptCommunityGuidelines: false,
-      needFeedback: false,
-      flowToken: "token",
-    };
-    window.localStorage.setItem("auth.flowState", JSON.stringify(state));
-    render(<View />, { wrapper });
-    expect(
-      await screen.findByText(t("auth:sign_up_confirmed_prompt"))
-    ).toBeVisible();
   });
 
   it("displays an error when present", async () => {

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -187,6 +187,10 @@ export async function validateUsername(username: string) {
   return res.getValid();
 }
 
+export async function getSignupFlow(token: string): Promise<SignupFlowRes> {
+  return http.get(`signup_flows/${token}/`, { omitAuthentication: true });
+}
+
 export async function unsubscribe(payload: string, sig: string) {
   const req = new UnsubscribeReq();
   req.setPayload(payload);


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Part of #264 

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `make format`
- [ ] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
