### PR TITLE
Make hero search hide hosts that can't host by default

### DIFF
--- a/features/dashboard/Hero/HeroSearch.tsx
+++ b/features/dashboard/Hero/HeroSearch.tsx
@@ -3,10 +3,10 @@ import LocationAutocomplete from "components/LocationAutocomplete";
 import { DASHBOARD } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
+import { HostingStatus } from "proto/api_pb";
 import { useForm } from "react-hook-form";
 import { routeToSearch } from "routes";
 import makeStyles from "utils/makeStyles";
-import { HostingStatus } from "proto/api_pb";
 
 const useStyles = makeStyles((theme) => ({
   searchBoxContainer: {
@@ -52,7 +52,7 @@ export default function HeroSearch() {
               hostingStatusOptions: [
                 HostingStatus.HOSTING_STATUS_CAN_HOST,
                 HostingStatus.HOSTING_STATUS_MAYBE,
-              ]
+              ],
             });
             router.push(searchRouteWithSearchQuery);
           }

--- a/features/dashboard/Hero/HeroSearch.tsx
+++ b/features/dashboard/Hero/HeroSearch.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "next-i18next";
 import { useForm } from "react-hook-form";
 import { routeToSearch } from "routes";
 import makeStyles from "utils/makeStyles";
+import { HostingStatus } from "proto/api_pb";
 
 const useStyles = makeStyles((theme) => ({
   searchBoxContainer: {
@@ -48,6 +49,10 @@ export default function HeroSearch() {
               location: value.simplifiedName,
               lat: value.location.lat,
               lng: value.location.lng,
+              hostingStatusOptions: [
+                HostingStatus.HOSTING_STATUS_CAN_HOST,
+                HostingStatus.HOSTING_STATUS_MAYBE,
+              ]
             });
             router.push(searchRouteWithSearchQuery);
           }


### PR DESCRIPTION
I think I did it right?
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ ] Formatted my code with `make format`
- [ ] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
