### PR TITLE
grammar and text fixes for hosting preferences and about home

### DIFF
--- a/features/profile/locales/en.json
+++ b/features/profile/locales/en.json
@@ -71,9 +71,9 @@
     },
     "edit_home_questions": {
         "accept_drinking": "Okay with drinking",
-        "accept_pets": "Can host pets",
+        "accept_pets": "Hosts pets",
         "accept_smoking": "Okay with smoking",
-        "accept_kids": "Can host children",
+        "accept_kids": "Hosts children",
         "accept_camping": "Tent camping available"
     },
     "unspecified_info": "Ask me",

--- a/features/profile/locales/en.json
+++ b/features/profile/locales/en.json
@@ -43,15 +43,15 @@
         "housemates": "Housemates",
         "housemate_details": "Housemate details",
         "kid_details": "Children details",
-        "last_minute": "Last-minute requests",
+        "last_minute": "Accept last-minute requests",
         "local_area": "Local area information",
-        "max_guests": "Max # of guests",
+        "max_guests": "Max number of guests",
         "my_home": "My home",
         "parking": "Parking available",
         "parking_details": "Parking details",
         "pet_details": "Pet details",
         "sleeping_arrangement": "Sleeping arrangement",
-        "space": "Private / shared space",
+        "space": "Sleeping privacy",
         "transportation": "Transportation, Parking, Accessibility",
         "wheelchair": "Wheelchair accessible",
         "other_info": "Additional information"
@@ -70,11 +70,11 @@
         "education": "Education"
     },
     "edit_home_questions": {
-        "accept_drinking": "Accept drinking",
-        "accept_pets": "Accept pets",
-        "accept_smoking": "Accept smoking",
-        "accept_kids": "Accept children",
-        "accept_camping": "Accept Camping"
+        "accept_drinking": "Okay with drinking",
+        "accept_pets": "Can host pets",
+        "accept_smoking": "Okay with smoking",
+        "accept_kids": "Can host children",
+        "accept_camping": "Tent camping available"
     },
     "unspecified_info": "Ask me",
     "smoking_location": {
@@ -84,8 +84,8 @@
         "yes": "Yes"
     },
     "sleeping_arrangement": {
-        "private": "Private",
-        "common": "Common",
+        "private": "Private space",
+        "common": "Common area",
         "shared_room": "Shared room",
         "shared_space": "Shared space"
     },


### PR DESCRIPTION
closes #116

made changes to translations files to address following points in the linked issue

> "Last minute requests" should be "Accepts last minute requests"

> "Accept camping" is grammatically incorrect and unclear. It should be "Tent camping available"

> "Accept children" & "accept pets" is grammatically incorrect and sounds strange. "Can host children" and "Can host guests with pets"

> "Accepts drinking" and "accepts smoking" also sounds strange. It should be "Okay with drinking" and "Okay with smoking"

> Also, the hashtag symbol # isn't universally understood as meaning "number", so it should say "Max number of hosts".

> Under "About my home" it is unclear that "Private / shared space" is referring to the room that the guest will be sleeping in. It should be changed to "Sleeping privacy". The options for hosts to choose should be changed from "shared" or "private" to "shared room" or "private room"

### Web frontend checklist

- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


### Screenshots

![image](https://github.com/Couchers-org/web-frontend/assets/8488446/c3f081e7-d2fa-43fb-bdcd-a4e228112665)
![image](https://github.com/Couchers-org/web-frontend/assets/8488446/c4f138f1-d1e8-4e3d-a27b-6047a8f92cfa)
![image](https://github.com/Couchers-org/web-frontend/assets/8488446/799e8a30-d1b3-494f-b3ba-f916cb7ec550)

