### PR TITLE
fix: order of countries in edit profile selects

### DIFF
--- a/features/profile/ProfileTagInput.tsx
+++ b/features/profile/ProfileTagInput.tsx
@@ -248,7 +248,7 @@ export default function ProfileTagInput({
           disablePortal
           options={options
             .concat(pendingValue.filter((item) => options.indexOf(item) < 0))
-            .sort((a, b) => -b[0].localeCompare(a[0]))}
+            .sort((a, b) => -b.localeCompare(a))}
           renderOption={(option, { selected }) => (
             <>
               <Checkbox


### PR DESCRIPTION
Countries were getting sorted based on only first character in the country name. changed it to compare the whole string

Closes #305 

### Web frontend checklist

- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


### Screenshots

#### Before
![image](https://github.com/Couchers-org/web-frontend/assets/8488446/637795d2-b03d-438b-b8f4-cd02fe431e25)


#### After
![image](https://github.com/Couchers-org/web-frontend/assets/8488446/3f3c05ba-aa8f-439e-a260-77e83bb66385)
