### PR TITLE
Redirect to dashboard (not login) when logo clicked

### DIFF
--- a/resources/CouchersLogo.tsx
+++ b/resources/CouchersLogo.tsx
@@ -1,5 +1,6 @@
 import { Chip, SvgIcon } from "@material-ui/core";
 import classNames from "classnames";
+import { useAuthContext } from "features/auth/AuthProvider";
 import Link from "next/link";
 import makeStyles from "utils/makeStyles";
 
@@ -26,8 +27,10 @@ export interface CouchersLogoProps {
 
 export default function CouchersLogo({ className }: CouchersLogoProps) {
   const classes = useStyles();
+  const { authState } = useAuthContext();
+
   return (
-    <Link href="/">
+    <Link href={authState.authenticated ? "/dashboard" : "/login"}>
       <a className={classes.root}>
         <SvgIcon
           className={classNames(classes.logo, className)}


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
closes https://github.com/Couchers-org/web-frontend/issues/376
Currently clicking the logo in navbar directs to login page, now it directs to the dashboard instead. 
(if you're not logged in, navigating to dashboard will be redirected to the login page)

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ /] Formatted my code with `make format`
- [ /] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [ /] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
