### PR TITLE
build: Update dev mapbox key to not use the preview/prod one

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,8 @@
 NEXT_PUBLIC_COUCHERS_ENV=preview
 NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
 NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
-NEXT_PUBLIC_MAPBOX_KEY="pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzVnaXA0MGdmejJ4bGFrdTdrNjA0NCJ9.1VAPRbE6a_kwGw1kucppJw"
+NEXT_PUBLIC_MAPBOX_KEY="pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzY4eHd2MGVpcTJ0bGdhdGhvbHhlbiJ9.u5zvDeFE9H8itTK_dNp7Pg"
+
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
 NEXT_PUBLIC_TILE_URL="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 NEXT_PUBLIC_TILE_ATTRIBUTION="Map data &copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors"


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
I found that the Mapbox key (`NEXT_PUBLIC_MAPBOX_KEY`) was using the key intended for deployed instances of our site (on next/prod), and so was breaking the map when I spun up the app locally.

Turned out the key was already in `.env.localdev`, but that particular copy of `.env` is only useful if you plan to run the Couchers platform locally e2e, which I assume most of you aren't doing (i.e. you're hitting the API on `next`).

Copying the value over fixes the issue as that key is meant for `localhost` host names/local dev environments.

<!---
Checklists
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
N/A - no code changes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
